### PR TITLE
Use `unlet!` instead of `unlet` to avoid E108 errors

### DIFF
--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -25,7 +25,7 @@ endif
 let g:loaded_cyfolds = 1
 
 let b:undo_ftplugin = "setl foldmethod< foldtext< foldexpr< foldenable< ofu<"
-                  \ . "| unlet b:match_ignorecase b:match_words b:suppress_insert_mode_switching"
+                  \ . "| unlet! b:match_ignorecase b:match_words b:suppress_insert_mode_switching"
                   \ . " b:insert_saved_foldmethod b:update_saved_foldmethod"
 
 " What is the overhead of calling Python from Vim?  The cached foldlevel


### PR DESCRIPTION
When opening python files, the following error often occured:

```
Error detected while processing function <SNR>20_LoadFTPlugin:
line    2:
E108: No such variable: "b:match_words"
```

To avoid this error, we should use `unlet!` instead of `unlet` for
undo_ftplugin commands.